### PR TITLE
Added _TZ3000_402vrq2i to button-battery-knob fingerprints

### DIFF
--- a/zigbee/button-battery-knob/fingerprints.yaml
+++ b/zigbee/button-battery-knob/fingerprints.yaml
@@ -39,3 +39,10 @@ zigbeeManufacturer:
     manufacturer: "_TZ3000_qja6nq5z"
     model: "TS004F"
     deviceProfileName: button-battery
+
+    # Smart Knob
+  - id: "_TZ3000_402vrq2i/TS004F"
+    deviceLabel: "Smart Knob"
+    manufacturer: "_TZ3000_402vrq2i"
+    model: "TS004F"
+    deviceProfileName: button-battery


### PR DESCRIPTION
Added fingerprint for another smart knob manufacturer. Devices can be found on Aliexpress listing: 1005007720682666 and similar